### PR TITLE
https://github.com/advantageous/reakt/issues/52 done

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 group 'io.advantageous.reakt'
-version '3.0.8'
+version '3.1.0'
 
 apply plugin: 'java'
 apply plugin: 'maven'

--- a/src/main/java/io/advantageous/reakt/Callback.java
+++ b/src/main/java/io/advantageous/reakt/Callback.java
@@ -41,7 +41,7 @@ import static io.advantageous.reakt.Result.doneResult;
  * @author Rick Hightower
  * @author Geoff Chandler
  */
-public interface Callback<T> extends Consumer<T> {
+public interface Callback<T> extends Consumer<T>, CallbackHandle<T> {
 
     /**
      * (Client view)

--- a/src/main/java/io/advantageous/reakt/CallbackHandle.java
+++ b/src/main/java/io/advantageous/reakt/CallbackHandle.java
@@ -1,0 +1,60 @@
+package io.advantageous.reakt;
+
+
+
+/**
+ * Simplified interface to a callback, hiding a callbacks hierarchy and dual roles.
+ * This is the service view of a callback.
+ * This focuses on just resolution methods of a callback.
+ */
+public interface CallbackHandle<T> {
+
+    /**
+     * (Service view)
+     * This allows services to send back a failed result easily to the client/handler.
+     * <p>
+     * This is a helper methods for producers (services that produce results) to send a failed result.
+     *
+     * @param error error
+     */
+    void reject(final Throwable error) ;
+
+
+    /**
+     * (Service view)
+     * This allows services to send back a failed result easily to the client/handler.
+     * <p>
+     * This is a helper methods for producers (services that produce results) to send a failed result.
+     *
+     * @param errorMessage error message
+     */
+    void reject(final String errorMessage);
+
+
+    /**
+     * (Service view)
+     * This allows services to send back a failed result easily to the client/handler.
+     * <p>
+     * This is a helper methods for producers (services that produce results) to send a failed result.
+     *
+     * @param errorMessage error message
+     * @param error        exception
+     */
+    void reject(final String errorMessage, final Throwable error) ;
+
+
+
+    /**
+     * Calls replayDone, for VOID callback only. ES6 promise style.
+     */
+    void resolve();
+
+    /**
+     * Resolve resolves a promise.
+     *
+     * @param result makes it more compatible with ES6 style promises
+     */
+    void resolve(final T result);
+
+
+}

--- a/src/main/java/io/advantageous/reakt/promise/Promise.java
+++ b/src/main/java/io/advantageous/reakt/promise/Promise.java
@@ -43,7 +43,7 @@ import java.util.function.Function;
  * @author Rick Hightower
  * @author Geoff Chandler
  */
-public interface Promise<T> extends Callback<T>, Result<T> {
+public interface Promise<T> extends Callback<T>, Result<T>, PromiseHandle<T> {
 
     /**
      * Creates an immutable promise.
@@ -187,9 +187,22 @@ public interface Promise<T> extends Callback<T>, Result<T> {
         return this;
     }
 
+    /**
+     * Use this to run the promise in replay mode on a reactor.
+     * Allows a promise to be invoked with a reactor
+     * @param reactor reactor to use
+     * @return new Promise that wraps the promise. New promise is associated with the reactor.
+     */
     Promise<T> invokeWithReactor(Reactor reactor);
 
 
+    /**
+     * Use this to run the promise in replay mode on a reactor.
+     * Allows a promise to be invoked with a reactor
+     * @param reactor reactor to use
+     * @param timeout if the promise does not return in the allotted time, the reactor will time it out.
+     * @return new Promise that wraps the promise. New promise is associated with the reactor.
+     */
     Promise<T> invokeWithReactor(Reactor reactor, Duration timeout);
 
     /**
@@ -268,7 +281,7 @@ public interface Promise<T> extends Callback<T>, Result<T> {
     /**
      * Used for testing and legacy integration.
      * This turns an async promise into a blocking promise.
-     * @param duration duration
+     * @param duration duration to wait for call
      * @return blocking promise
      */
     default Promise<T> invokeAsBlockingPromise(Duration duration) {
@@ -276,4 +289,26 @@ public interface Promise<T> extends Callback<T>, Result<T> {
         this.invokeWithPromise(blockingPromise);
         return blockingPromise;
     }
+
+
+    /**
+     * Used for testing and legacy integration.
+     * This turns an async promise into a blocking promise and then does a get operations.
+     * @param duration duration to wait for call
+     * @return result of call, blocks until return comes back.
+     */
+    default T blockingGet(Duration duration) {
+        return invokeAsBlockingPromise(duration).get();
+    }
+
+    /**
+     * Used for testing and legacy integration.
+     * This turns an async promise into a blocking promise and then does a get operations.
+     * @return result of call, blocks until return comes back.
+     */
+    default T blockingGet() {
+        return invokeAsBlockingPromise().get();
+    }
+
+
 }

--- a/src/main/java/io/advantageous/reakt/promise/PromiseHandle.java
+++ b/src/main/java/io/advantageous/reakt/promise/PromiseHandle.java
@@ -1,0 +1,146 @@
+package io.advantageous.reakt.promise;
+
+import io.advantageous.reakt.Expected;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+/**
+ * Simplified interface to promise that hides the complexity and hierarchy of a Promise.
+ */
+public interface PromiseHandle<T> {
+
+
+    /**
+     * If a result is sent, and there was no error, then handle the result.
+     * <p>
+     * There is only one {@code then} Handler.
+     * </p>
+     * Unlike ES6, {@code then(..)} cannot be chained per se, but {@code whenComplete(..)}, and
+     * {@code }thenMap(...)} can be nested.
+     *
+     * @param consumer executed if result has no error.
+     * @return this, fluent API
+     * @throws NullPointerException if result is present and {@code consumer} is null
+     */
+    PromiseHandle<T> then(Consumer<T> consumer);
+
+    /**
+     * If a result is sent, and there was no error, then handle the result as a value which could be null.
+     * <p>
+     * There is only one thenExpect handler per promise.
+     * <p>
+     * Unlike ES6, {@code thenExpect(..)} cannot be chained per se as it does not create a new promise,
+     * but {@code whenComplete(..)}, and {@code }thenMap(...)} can be chained.
+     * <p>
+     * This does not create a new promise.
+     *
+     * @param consumer executed if result has no error.
+     * @return this, fluent API
+     * @throws NullPointerException if result is present and {@code consumer} is
+     *                              null
+     */
+    PromiseHandle<T> thenExpect(Consumer<Expected<T>> consumer);
+
+    /**
+     * If a result is sent, and there is an error, then handle handle the error.
+     *
+     * @param consumer executed if result has error.
+     * @return this, fluent API
+     * @throws NullPointerException if result is present and {@code consumer} is null
+     */
+    PromiseHandle<T> catchError(Consumer<Throwable> consumer);
+
+
+    /**
+     * Allows promises returned from, for example, proxy stubs for services methods to invoke the operation.
+     * <p>
+     * This allows use to set up the catchError and then before the method is async invoked.
+     * <p>
+     * Example Remote Proxy Gen to support returning Reakt invokeable promise
+     * <pre>
+     * <code>
+     *     employeeService.lookupEmployee("123")
+     *           .then((employee)-&gt; {...})
+     *           .catchError(...)
+     *           .invoke();
+     * </code>
+     * </pre>
+     *
+     * @return this, fluent
+     */
+    PromiseHandle<T> invoke();
+
+    /**
+     * If the thenSafeExpect handler throws an exception, this will report it as if it it was caught by catchError.
+     * <p>
+     * This is convenient if you are running your handler with an async lib that is not reporting or catching
+     * exceptions as your code is running on their threads.
+     * <p>
+     * If a result is sent, and there was no error, then handle the result as a value which could be null.
+     * <p>
+     * There is only one thenSafeExpect or thenExpect handler per promise.
+     * Once then is called all other then* handlers are safe.
+     * <p>
+     * Unlike ES6, {@code thenExpect(..)} cannot be chained per se as it does not create a new promise,
+     * but {@code whenComplete(..)}, and {@code }thenMap(...)} can be chained.
+     * <p>
+     * This does not create a new promise.
+     *
+     * @param consumer executed if result has no error.
+     * @return this, fluent API
+     * @throws NullPointerException if result is present and {@code consumer} is
+     *                              null
+     */
+    PromiseHandle<T> thenSafeExpect(Consumer<Expected<T>> consumer);
+
+
+    /**
+     * If the {@code then} handler throws an exception, this will report the exception as if it were caught
+     * by {@code catchError}.
+     * <p>
+     * This is convenient if you are running your handler with an async lib that is not reporting or catching
+     * exceptions as your code is running on their threads.
+     * <p>
+     * If a result is sent, and there was no error, then handle the result as a value which could be null.
+     * <p>
+     * There is only one thenSafe or then handler per promise.
+     * Once then is called all other then* handlers are safe.
+     * <p>
+     * Unlike ES6, {@code thenExpect(..)} cannot be chained per se as it does not create a new promise,
+     * but {@code whenComplete(..)}, and {@code }thenMap(...)} can be chained.
+     * <p>
+     * This does not create a new promise.
+     *
+     * @param consumer executed if result has no error.
+     * @return this, fluent API
+     * @throws NullPointerException if result is present and {@code consumer} is
+     *                              null
+     */
+    PromiseHandle<T> thenSafe(Consumer<T> consumer);
+
+
+    /**
+     * Used for testing and legacy integration.
+     * This turns an async promise into a blocking promise and then does a get operations.
+     * @param duration duration to wait for call
+     * @return result of call, blocks until return comes back.
+     */
+    T blockingGet(Duration duration);
+
+    /**
+     * Used for testing and legacy integration.
+     * This turns an async promise into a blocking promise and then does a get operations.
+     * @return result of call, blocks until return comes back.
+     */
+    T blockingGet();
+
+    /**
+     * If backed by a Promise then this will return that promise, otherwise throws an IllegalStateException.
+     * @return promise that backs this handle
+     */
+    default Promise<T> asPromise() {
+        return (Promise<T>) this;
+    }
+
+}

--- a/src/main/java/io/advantageous/reakt/promise/Promises.java
+++ b/src/main/java/io/advantageous/reakt/promise/Promises.java
@@ -18,6 +18,7 @@
 
 package io.advantageous.reakt.promise;
 
+import io.advantageous.reakt.CallbackHandle;
 import io.advantageous.reakt.promise.impl.*;
 
 import java.time.Duration;
@@ -984,7 +985,21 @@ public interface Promises {
      * @param promiseConsumer promise consumer so you can call reject or resolve on the service side
      * @return new promise
      */
+    @SuppressWarnings("all")
     static <T> Promise<T> invokablePromise(Consumer<Promise<T>> promiseConsumer) {
+        return new InvokerPromise<>((Consumer<CallbackHandle<T>>) (Object) promiseConsumer);
+    }
+
+    /**
+     * Create an invokable promise handle.
+     * After you create a promise handle you register its then(...) and catchError(...) and then you use it to
+     * handle a callback.
+     *
+     * @param <T>             type of result
+     * @param promiseConsumer promise consumer so you can call reject or resolve on the service side
+     * @return new promise
+     */
+    static <T> PromiseHandle<T> deferCall(Consumer<CallbackHandle<T>> promiseConsumer) {
         return new InvokerPromise<>(promiseConsumer);
     }
 }

--- a/src/main/java/io/advantageous/reakt/promise/impl/InvokerPromise.java
+++ b/src/main/java/io/advantageous/reakt/promise/impl/InvokerPromise.java
@@ -18,6 +18,7 @@
 
 package io.advantageous.reakt.promise.impl;
 
+import io.advantageous.reakt.CallbackHandle;
 import io.advantageous.reakt.Invokable;
 import io.advantageous.reakt.promise.Promise;
 
@@ -25,10 +26,10 @@ import java.util.function.Consumer;
 
 public class InvokerPromise<T> extends BasePromise<T> implements Invokable {
 
-    private final Consumer<Promise<T>> consumer;
+    private final Consumer<CallbackHandle<T>> consumer;
     private boolean invoked;
 
-    public InvokerPromise(Consumer<Promise<T>> consumer) {
+    public InvokerPromise(Consumer<CallbackHandle<T>> consumer) {
         this.consumer = consumer;
     }
 

--- a/src/main/java/io/advantageous/reakt/reactor/Reactor.java
+++ b/src/main/java/io/advantageous/reakt/reactor/Reactor.java
@@ -18,7 +18,10 @@
 
 package io.advantageous.reakt.reactor;
 
+import io.advantageous.reakt.CallbackHandle;
 import io.advantageous.reakt.promise.Promise;
+import io.advantageous.reakt.promise.PromiseHandle;
+import io.advantageous.reakt.promise.impl.InvokerPromise;
 import io.advantageous.reakt.reactor.impl.ReactorImpl;
 
 import java.time.Duration;
@@ -26,6 +29,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * Ensures that tasks, repeating tasks and callbacks run in the callers thread.
@@ -286,5 +290,6 @@ public interface Reactor {
      */
     @SuppressWarnings("unused")
     <T> Promise<Set<T>> promiseSet(final Class<T> componentType);
+
 
 }

--- a/src/main/java/io/advantageous/reakt/reactor/impl/ReactorImpl.java
+++ b/src/main/java/io/advantageous/reakt/reactor/impl/ReactorImpl.java
@@ -19,10 +19,13 @@
 package io.advantageous.reakt.reactor.impl;
 
 import io.advantageous.reakt.Callback;
+import io.advantageous.reakt.CallbackHandle;
 import io.advantageous.reakt.Expected;
 import io.advantageous.reakt.Result;
 import io.advantageous.reakt.promise.Promise;
+import io.advantageous.reakt.promise.PromiseHandle;
 import io.advantageous.reakt.promise.ReplayPromise;
+import io.advantageous.reakt.promise.impl.InvokerPromise;
 import io.advantageous.reakt.reactor.Reactor;
 import io.advantageous.reakt.reactor.TimeSource;
 


### PR DESCRIPTION
Simplify interface for using Promise lib. 

https://github.com/advantageous/qbit/issues/763

https://github.com/advantageous/reakt/issues/52

https://github.com/advantageous/reakt/pull/53

``` java

    interface ServiceDiscovery {
        PromiseHandle<URI> lookupServiceByPromiseHandle(final URI uri);
    }
```

A `promiseHandle` does not have as many methods it only has `then*`, `catch*`, `invoke`, and `blockingGet`. 
#### Usage

``` java

    public class ServiceDiscoveryImpl {

        public PromiseHandle<URI> lookupServiceByPromiseHandle(final URI uri) {
            return Promises.deferCall(callback -> {
                    if (uri == null) {
                        callback.reject("uri can't be null");
                    } else {
                        callback.resolve(successResult);
                    }
                });
        }
```

Instead of `invokeablePromise` from `Promises`, you use `Promises.deferCall` which returns a `PromiseHandle` and takes a `Consumer<CallbackHandle>`.

`Promises.deferCall` is preferred. 
#### CallbackHandle

``` java
package io.advantageous.reakt;



/**
 * Simplified interface to a callback, hiding a callbacks hierarchy and dual roles.
 * This is the service view of a callback.
 * This focuses on just resolution methods of a callback.
 */
public interface CallbackHandle<T> {

    /**
     * (Service view)
     * This allows services to send back a failed result easily to the client/handler.
     * <p>
     * This is a helper methods for producers (services that produce results) to send a failed result.
     *
     * @param error error
     */
    void reject(final Throwable error) ;


    /**
     * (Service view)
     * This allows services to send back a failed result easily to the client/handler.
     * <p>
     * This is a helper methods for producers (services that produce results) to send a failed result.
     *
     * @param errorMessage error message
     */
    void reject(final String errorMessage);


    /**
     * (Service view)
     * This allows services to send back a failed result easily to the client/handler.
     * <p>
     * This is a helper methods for producers (services that produce results) to send a failed result.
     *
     * @param errorMessage error message
     * @param error        exception
     */
    void reject(final String errorMessage, final Throwable error) ;



    /**
     * Calls replayDone, for VOID callback only. ES6 promise style.
     */
    void resolve();

    /**
     * Resolve resolves a promise.
     *
     * @param result makes it more compatible with ES6 style promises
     */
    void resolve(final T result);


}

```

A `CallbackHandle` has five methods for resolution.
#### PromiseHandle

``` java
package io.advantageous.reakt.promise;

import io.advantageous.reakt.Expected;

import java.time.Duration;
import java.util.function.Consumer;

/**
 * Simplified interface to promise that hides the complexity and hierarchy of a Promise.
 */
public interface PromiseHandle<T> {


    /**
     * If a result is sent, and there was no error, then handle the result.
     * <p>
     * There is only one {@code then} Handler.
     * </p>
     * Unlike ES6, {@code then(..)} cannot be chained per se, but {@code whenComplete(..)}, and
     * {@code }thenMap(...)} can be nested.
     *
     * @param consumer executed if result has no error.
     * @return this, fluent API
     * @throws NullPointerException if result is present and {@code consumer} is null
     */
    PromiseHandle<T> then(Consumer<T> consumer);

    /**
     * If a result is sent, and there was no error, then handle the result as a value which could be null.
     * <p>
     * There is only one thenExpect handler per promise.
     * <p>
     * Unlike ES6, {@code thenExpect(..)} cannot be chained per se as it does not create a new promise,
     * but {@code whenComplete(..)}, and {@code }thenMap(...)} can be chained.
     * <p>
     * This does not create a new promise.
     *
     * @param consumer executed if result has no error.
     * @return this, fluent API
     * @throws NullPointerException if result is present and {@code consumer} is
     *                              null
     */
    PromiseHandle<T> thenExpect(Consumer<Expected<T>> consumer);

    /**
     * If a result is sent, and there is an error, then handle handle the error.
     *
     * @param consumer executed if result has error.
     * @return this, fluent API
     * @throws NullPointerException if result is present and {@code consumer} is null
     */
    PromiseHandle<T> catchError(Consumer<Throwable> consumer);


    /**
     * Allows promises returned from, for example, proxy stubs for services methods to invoke the operation.
     * <p>
     * This allows use to set up the catchError and then before the method is async invoked.
     * <p>
     * Example Remote Proxy Gen to support returning Reakt invokeable promise
     * <pre>
     * <code>
     *     employeeService.lookupEmployee("123")
     *           .then((employee)-&gt; {...})
     *           .catchError(...)
     *           .invoke();
     * </code>
     * </pre>
     *
     * @return this, fluent
     */
    PromiseHandle<T> invoke();

    /**
     * If the thenSafeExpect handler throws an exception, this will report it as if it it was caught by catchError.
     * <p>
     * This is convenient if you are running your handler with an async lib that is not reporting or catching
     * exceptions as your code is running on their threads.
     * <p>
     * If a result is sent, and there was no error, then handle the result as a value which could be null.
     * <p>
     * There is only one thenSafeExpect or thenExpect handler per promise.
     * Once then is called all other then* handlers are safe.
     * <p>
     * Unlike ES6, {@code thenExpect(..)} cannot be chained per se as it does not create a new promise,
     * but {@code whenComplete(..)}, and {@code }thenMap(...)} can be chained.
     * <p>
     * This does not create a new promise.
     *
     * @param consumer executed if result has no error.
     * @return this, fluent API
     * @throws NullPointerException if result is present and {@code consumer} is
     *                              null
     */
    PromiseHandle<T> thenSafeExpect(Consumer<Expected<T>> consumer);


    /**
     * If the {@code then} handler throws an exception, this will report the exception as if it were caught
     * by {@code catchError}.
     * <p>
     * This is convenient if you are running your handler with an async lib that is not reporting or catching
     * exceptions as your code is running on their threads.
     * <p>
     * If a result is sent, and there was no error, then handle the result as a value which could be null.
     * <p>
     * There is only one thenSafe or then handler per promise.
     * Once then is called all other then* handlers are safe.
     * <p>
     * Unlike ES6, {@code thenExpect(..)} cannot be chained per se as it does not create a new promise,
     * but {@code whenComplete(..)}, and {@code }thenMap(...)} can be chained.
     * <p>
     * This does not create a new promise.
     *
     * @param consumer executed if result has no error.
     * @return this, fluent API
     * @throws NullPointerException if result is present and {@code consumer} is
     *                              null
     */
    PromiseHandle<T> thenSafe(Consumer<T> consumer);


    /**
     * Used for testing and legacy integration.
     * This turns an async promise into a blocking promise and then does a get operations.
     * @param duration duration to wait for call
     * @return result of call, blocks until return comes back.
     */
    T blockingGet(Duration duration);

    /**
     * Used for testing and legacy integration.
     * This turns an async promise into a blocking promise and then does a get operations.
     * @return result of call, blocks until return comes back.
     */
    T blockingGet();

    /**
     * If backed by a Promise then this will return that promise, otherwise throws an IllegalStateException.
     * @return promise that backs this handle
     */
    default Promise<T> asPromise() {
        return (Promise<T>) this;
    }

}

```

``` java
class Promises { ...

    /**
     * Create an invokable promise handle.
     * After you create a promise handle you register its then(...) and catchError(...) and then you use it to
     * handle a callback.
     *
     * @param <T>             type of result
     * @param promiseConsumer promise consumer so you can call reject or resolve on the service side
     * @return new promise
     */
    static <T> PromiseHandle<T> deferCall(Consumer<CallbackHandle<T>> promiseConsumer) {
        return new InvokerPromise<>(promiseConsumer);
    }
```
